### PR TITLE
feat: fix autocomplete of debounce and throttle utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.11 - 2025-4-18
+
+This pull request involves a minor reorganization of dependencies across `package.json` files. The `use-debounce` library has been moved from the main `package.json` to the `packages/lib/package.json`, likely to better align with its usage.
+
+
 # 1.1.10 - 2025-4-18
 
 Debounce and Throttle are two main concepts that NEEDs to be available in any application and need to have easy ways to access them through the UI library instead of only in language level.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,7 @@
       "workspaces": [
         "playground/*",
         "packages/*"
-      ],
-      "dependencies": {
-        "use-debounce": "^10.0.4"
-      }
+      ]
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
@@ -7083,7 +7080,7 @@
     },
     "packages/lib": {
       "name": "@omariosouto/common-ui-web",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.4",
@@ -7106,6 +7103,7 @@
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.3",
         "tw-animate-css": "^1.2.5",
+        "use-debounce": "^10.0.4",
         "vitest": "^3.1.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "use-debounce": "^10.0.4"
-  }
+  "description": ""
 }

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.11 - 2025-4-18
+
+This pull request involves a minor reorganization of dependencies across `package.json` files. The `use-debounce` library has been moved from the main `package.json` to the `packages/lib/package.json`, likely to better align with its usage.
+
+
 # 1.1.10 - 2025-4-18
 
 Debounce and Throttle are two main concepts that NEEDs to be available in any application and need to have easy ways to access them through the UI library instead of only in language level.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -57,7 +57,8 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.3",
     "tw-animate-css": "^1.2.5",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "use-debounce": "^10.0.4"
   },
   "devDependencies": {
     "@omariosouto/tsconfig": "1.13.11",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-ui-web",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "main": "dist/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

This pull request involves a minor reorganization of dependencies across `package.json` files. The `use-debounce` library has been moved from the main `package.json` to the `packages/lib/package.json`, likely to better align with its usage.