### PR TITLE
feat: add common peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.1.13 - 2025-4-19
+
+This pull request introduces new dependencies on `@omariosouto/common-core` and `@omariosouto/common-errors` libraries, while also refactoring code to utilize the `sleep` utility from `@omariosouto/common-core` instead of duplicating it locally. These changes improve code reuse and consistency across the project.
+### Dependency Updates:
+* Added `@omariosouto/common-core` and `@omariosouto/common-errors` as `peerDependencies` and `devDependencies` in `packages/lib/package.json`. This ensures these libraries are available for shared functionality and error handling. [[1]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5L37-R39) [[2]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5R67-R68)
+### Code Refactoring:
+* Updated `playground/example-nextjs/app/async-state/client.tsx` to use the `sleep` utility from `@omariosouto/common-core`, removing the locally defined `sleep` function.
+* Refactored `playground/example-nextjs/app/state/httpClient.tsx` to replace the local `sleep` function with the imported version from `@omariosouto/common-core`.
+
+
 # 1.1.12 - 2025-4-18
 
 Reference guide to guide abstractions related to asyncState on UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1495,6 +1495,23 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@omariosouto/common-core": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-core/1.0.1/a00f893f40c3675908f55cda481618d1f7d0d745",
+      "integrity": "sha512-1Lp9DNrwF0wQ+/4BjUF0deXpR77UtL4NGxTZmV4Huz4UKqmKg4qpG7eRkrdbii4lH0uuzGpJEh0BniQM6oAUEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/@omariosouto/common-errors": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@omariosouto/common-errors/1.0.1/572d404306c567680174faa2511fad75c108f837",
+      "integrity": "sha512-MAyMZqOsjBvZ+tm6LB+28k06cX8fctPZTAq54Sj8cfOE3Z7s2PlMPWtLhgfqXZCg4a3AFto4BeTda5qlwpqzOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@omariosouto/common-ui-web": {
       "resolved": "packages/lib",
       "link": true
@@ -5088,6 +5105,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7092,7 +7116,7 @@
     },
     "packages/lib": {
       "name": "@omariosouto/common-ui-web",
-      "version": "1.1.10",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.4",
@@ -7120,6 +7144,8 @@
         "vitest": "^3.1.1"
       },
       "devDependencies": {
+        "@omariosouto/common-core": "^1.0.1",
+        "@omariosouto/common-errors": "^1.0.1",
         "@omariosouto/tsconfig": "1.13.11",
         "@types/node": "^22.14.1",
         "@types/react": "19.1.1",
@@ -7129,6 +7155,8 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
+        "@omariosouto/common-core": "^1.0.0 || ^2.0.0",
+        "@omariosouto/common-errors": "^1.0.0 || ^2.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,6 +3256,23 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
@@ -7147,6 +7164,7 @@
         "@omariosouto/common-core": "^1.0.1",
         "@omariosouto/common-errors": "^1.0.1",
         "@omariosouto/tsconfig": "1.13.11",
+        "@types/lodash-es": "latest",
         "@types/node": "^22.14.1",
         "@types/react": "19.1.1",
         "react": "^19.1.0",

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.1.13 - 2025-4-19
+
+This pull request introduces new dependencies on `@omariosouto/common-core` and `@omariosouto/common-errors` libraries, while also refactoring code to utilize the `sleep` utility from `@omariosouto/common-core` instead of duplicating it locally. These changes improve code reuse and consistency across the project.
+### Dependency Updates:
+* Added `@omariosouto/common-core` and `@omariosouto/common-errors` as `peerDependencies` and `devDependencies` in `packages/lib/package.json`. This ensures these libraries are available for shared functionality and error handling. [[1]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5L37-R39) [[2]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5R67-R68)
+### Code Refactoring:
+* Updated `playground/example-nextjs/app/async-state/client.tsx` to use the `sleep` utility from `@omariosouto/common-core`, removing the locally defined `sleep` function.
+* Refactored `playground/example-nextjs/app/state/httpClient.tsx` to replace the local `sleep` function with the imported version from `@omariosouto/common-core`.
+
+
 # 1.1.12 - 2025-4-18
 
 Reference guide to guide abstractions related to asyncState on UI

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,7 +34,9 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "@omariosouto/common-core": "^1.0.0 || ^2.0.0",
+    "@omariosouto/common-errors": "^1.0.0 || ^2.0.0"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.4",
@@ -62,6 +64,8 @@
     "use-debounce": "^10.0.4"
   },
   "devDependencies": {
+    "@omariosouto/common-core": "^1.0.1",
+    "@omariosouto/common-errors": "^1.0.1",
     "@omariosouto/tsconfig": "1.13.11",
     "@types/node": "^22.14.1",
     "@types/react": "19.1.1",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -69,6 +69,7 @@
     "@omariosouto/tsconfig": "1.13.11",
     "@types/node": "^22.14.1",
     "@types/react": "19.1.1",
+    "@types/lodash-es": "latest",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tsup": "^8.4.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-ui-web",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/playground/example-nextjs/app/async-state/client.tsx
+++ b/playground/example-nextjs/app/async-state/client.tsx
@@ -1,9 +1,8 @@
 "use client";
 import { useAsyncStateQuery } from "@omariosouto/common-ui-web/state";
 import { Box, Button, Text } from "@omariosouto/common-ui-web/components";
+import { sleep } from "@omariosouto/common-core";
 import { getGitHubUserInfo, GitHubRepo } from "./httpClient";
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const githubStateKeys = {
   profile: () => ["profile"] as const,

--- a/playground/example-nextjs/app/state/httpClient.tsx
+++ b/playground/example-nextjs/app/state/httpClient.tsx
@@ -1,13 +1,10 @@
+import { sleep } from "@omariosouto/common-core";
 import { Todo } from "../api/todos/domain";
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function httpClient_getTodos({
   delay = 0.5,
 } = {}): Promise<Todo[]> {
   await sleep(delay * 1000);
-
-
   
   return fetch("/api/todos")
     .then((res) => res.json())


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

This pull request introduces new dependencies on `@omariosouto/common-core` and `@omariosouto/common-errors` libraries, while also refactoring code to utilize the `sleep` utility from `@omariosouto/common-core` instead of duplicating it locally. These changes improve code reuse and consistency across the project.

### Dependency Updates:
* Added `@omariosouto/common-core` and `@omariosouto/common-errors` as `peerDependencies` and `devDependencies` in `packages/lib/package.json`. This ensures these libraries are available for shared functionality and error handling. [[1]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5L37-R39) [[2]](diffhunk://#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5R67-R68)

### Code Refactoring:
* Updated `playground/example-nextjs/app/async-state/client.tsx` to use the `sleep` utility from `@omariosouto/common-core`, removing the locally defined `sleep` function.
* Refactored `playground/example-nextjs/app/state/httpClient.tsx` to replace the local `sleep` function with the imported version from `@omariosouto/common-core`.
